### PR TITLE
Z-Library.Z-Library: Update download URL

### DIFF
--- a/bucket/z/Z-Library/Z-Library.Z-Library.json
+++ b/bucket/z/Z-Library/Z-Library.Z-Library.json
@@ -7,8 +7,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://s3proxy.cdn-zlib.sk/te_public_files/soft/windows/zlibrary-setup-latest.exe#/dl.7z",
-            "hash": "55c51fbfbfd4f71c9e824d76d6a04e8af04e1d6cde0dcf87260cc561cf111284"
+            "url": "https://s3proxy-alp.cdn-zlib.sk/te_public_files/soft/desktop/Z-Library-latest.exe#/dl.7z",
+            "hash": "0aed1fa63600932ff462be943cfecc81dafae9e6718f8313823b474980f63c72"
         }
     },
     "shortcuts": [
@@ -48,7 +48,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://s3proxy.cdn-zlib.sk/te_public_files/soft/windows/zlibrary-setup-latest.exe#/dl.7z"
+                "url": "https://s3proxy-alp.cdn-zlib.sk/te_public_files/soft/desktop/Z-Library-latest.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
This PR fixes the installation failure for the Z-Library application.

#### The Problem
The previous download URL for Z-Library (`https://s3proxy.cdn-zlib.sk/...`) has become invalid, which prevents users from installing or updating the app.

#### The Solution
- The `url` has been updated to the new, working endpoint provided by Z-Library.
- The file `hash` has been recalculated and updated to match the new executable.

I have tested the updated manifest locally with `scoop install` and `scoop uninstall`, and it works as expected.

This should resolve the installation issue for all users.